### PR TITLE
Fix the PHP file icon setting for ST build 3092.

### DIFF
--- a/Prefs/icon_php.tmPreferences
+++ b/Prefs/icon_php.tmPreferences
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>scope</key>
-    <string>source.php</string>
+    <string>source.php, embedding.php</string>
     <key>settings</key>
     <dict>
         <key>icon</key>


### PR DESCRIPTION
In the latest ST build (dev 3092), the main scope for a `.php` file is `embedding.php` rather than `source.php`.
